### PR TITLE
python3.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ feel free to use the code in any way that helps you get
 some awesome science done!
  
 
-
 ### Installation ###
 
 The easiest way to install NMRPyStar is using pip:
@@ -31,7 +30,7 @@ If it was installed with `pip`, it can be easily uninstalled:
 
 ### Quick Start ###
 
-You've already got NMRPyStar installed and importable?  Great!
+
 It's easy to start parsing NMR-STAR files:
 
     import nmrpystar
@@ -44,12 +43,22 @@ It's easy to start parsing NMR-STAR files:
     else:
         print 'uh-oh, there was a problem with the string I gave it ... ', parsed
 
+Or try out one of the examples:
+
+    ./integration-tests.sh
+
+
+### Running the tests
+
+```bash
+python3 -m unittest
+```
 
 
 ### Python version ###
 
-This library was created for use with Python2.7.  Although it may work
-with other Python versions, I haven't tried that.
+This library was created for use with Python3.  I'm working on making it compatible
+with Python2 as well.
 
 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ some awesome science done!
 
 The easiest way to install NMRPyStar is using pip:
 
-    $ pip install nmrpystar
+```bash
+pip3 install nmrpystar
+```
 
 If you don't have pip or easy_install, you can download the package
 manually from [the pypi page](https://pypi.python.org/pypi/NMRPyStar).
@@ -24,8 +26,9 @@ manually from [the pypi page](https://pypi.python.org/pypi/NMRPyStar).
 
 If it was installed with `pip`, it can be easily uninstalled:
 
-    $ pip uninstall nmrpystar
-
+```bash
+$ pip3 uninstall nmrpystar
+```
 
 
 ### Quick Start ###
@@ -33,20 +36,23 @@ If it was installed with `pip`, it can be easily uninstalled:
 
 It's easy to start parsing NMR-STAR files:
 
-    import nmrpystar
-    
-    myString = ...read a file/url/stdin/string...
-    
-    parsed = nmrpystar.parse(myString)
-    if parsed.status == 'success':
-        print 'it worked!!  ', parsed.value
-    else:
-        print 'uh-oh, there was a problem with the string I gave it ... ', parsed
+```python
+import nmrpystar
+
+myString = ...read a file/url/stdin/string...
+
+parsed = nmrpystar.parse(myString)
+if parsed.status == 'success':
+    print 'it worked!!  ', parsed.value
+else:
+    print 'uh-oh, there was a problem with the string I gave it ... ', parsed
+```
 
 Or try out one of the examples:
 
-    ./integration-tests.sh
-
+```bash
+./integration-tests.sh
+```
 
 ### Running the tests
 
@@ -59,7 +65,6 @@ python3 -m unittest
 
 This library was created for use with Python3.  I'm working on making it compatible
 with Python2 as well.
-
 
 
 ### Motivation ###

--- a/README.md
+++ b/README.md
@@ -232,3 +232,11 @@ Parser Combinators: a Practical Application for Generating Parsers for NMR Data
 Found a bug?  Need help figuring something out?  Want a new feature?  Feel free
 to report anything using the github issue tracker, or email me directly at
 mfenwick100 at gmail dot com
+
+### How to cut a release
+
+ - update version strings
+ - `python3 -m pip install --user --upgrade setuptools wheel`
+ - `python3 setup.py sdist bdist_wheel`
+ - `pip3 install twine`
+ - `twine upload dist/*`

--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ mfenwick100 at gmail dot com
 
 ### How to cut a release
 
+See [here](https://towardsdatascience.com/publishing-your-own-python-package-3762f0d268ec) for instructions:
+
  - update version strings
  - `python3 -m pip install --user --upgrade setuptools wheel`
  - `python3 setup.py sdist bdist_wheel`

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -1,0 +1,8 @@
+echo 'running stdin example'
+cat examples/star18504.txt | python3 -m nmrpystar.examples.full stdin
+
+echo 'running file example'
+python3 -m nmrpystar.examples.full file
+
+echo 'running url example'
+python3 -m nmrpystar.examples.full url

--- a/issues.md
+++ b/issues.md
@@ -1,4 +1,0 @@
-Issues:
-
- - line number counting:  currently only considers `\n` to be a newline --
-   doesn't bump line number for `\r`

--- a/nmrpystar/__init__.py
+++ b/nmrpystar/__init__.py
@@ -1,2 +1,11 @@
-   
-__version__ = '0.1.0'
+from .parser import parse_nmrstar_ast
+
+parse = parse_nmrstar_ast
+
+__version__ = '1.0.0'
+
+__all__ = [
+    "parse",
+    "parse_nmrstar_ast",
+]
+

--- a/nmrpystar/examples/__init__.py
+++ b/nmrpystar/examples/__init__.py
@@ -1,2 +1,2 @@
-from .loading import *
-from .queries import *
+from nmrpystar.examples.loading import *
+from nmrpystar.examples.queries import *

--- a/nmrpystar/examples/full.py
+++ b/nmrpystar/examples/full.py
@@ -1,15 +1,13 @@
-from .. import parser
-import json
-import urllib2
+from nmrpystar import parser
+from urllib import request
 import numpy
 import sys
 
 
 def parseUrl(url):
-    page = urllib2.urlopen(url)
-    inputStr = page.read()
-    page.close()
-    return parser.parse_nmrstar_ast(inputStr)
+    with request.urlopen(url) as page:
+        inputStr = page.read().decode('utf-8')
+        return parser.parse_nmrstar_ast(inputStr)
 
 def parseFile(path):
     with open(path, 'r') as my_file:
@@ -33,7 +31,7 @@ def query(model):
     many = [(k, (len(v), numpy.std(v))) for (k, v) in shifts.items()]
     devs = filter(lambda x: x[1][0] > 1, sorted(many, key=lambda x: x[0]))
     for result in sorted(devs, key=lambda x: (x[0][1], x[1][1])):
-        print result
+        print(result)
     return None
 
 def from_url():

--- a/nmrpystar/examples/full.py
+++ b/nmrpystar/examples/full.py
@@ -49,13 +49,13 @@ def from_stdin():
     if result.status == 'success':
         return query(result.value)
 
-mode = sys.argv[1]
-if mode == 'url':
-    from_url()
-elif mode == 'file':
-    from_file()
-elif mode == 'stdin':
-    from_stdin()
-else:
-    raise ValueError('invalid mode -- %s' % mode)
-
+if __name__ == "__main__":
+    mode = sys.argv[1]
+    if mode == 'url':
+        from_url()
+    elif mode == 'file':
+        from_file()
+    elif mode == 'stdin':
+        from_stdin()
+    else:
+        raise ValueError('invalid mode -- %s' % mode)

--- a/nmrpystar/examples/loading.py
+++ b/nmrpystar/examples/loading.py
@@ -1,5 +1,5 @@
-from .. import parser
-import urllib2
+from nmrpystar import parser
+import urllib.request
 import sys
 import json
 
@@ -40,7 +40,7 @@ def parseFile(path):
 
 def parseUrl(myUrl='http://rest.bmrb.wisc.edu/bmrb/NMR-STAR3/248'): # this is the url of an NMR-Star3 file
     #url2 = 'http://rest.bmrb.wisc.edu/bmrb/NMR-STAR2/248'
-    page = urllib2.urlopen(myUrl)
+    page = urllib.request.urlopen(myUrl)
     inputStr = page.read()
     page.close()
     return withInput(inputStr)
@@ -52,4 +52,4 @@ def parseStdin():
 
 
 if __name__ == "__main__":
-    print json.dumps(parseStdin()[1].toJSONObject())
+    print(json.dumps(parseStdin()[1].toJSONObject()))

--- a/nmrpystar/examples/profile.py
+++ b/nmrpystar/examples/profile.py
@@ -1,6 +1,6 @@
 import cProfile
 import pstats
-from . import loading
+from nmrpystar.examples import loading
 
 
 def parseFile(path):

--- a/nmrpystar/examples/queries.py
+++ b/nmrpystar/examples/queries.py
@@ -5,17 +5,17 @@ def getChemicalShifts(dataBlock, saveShiftName='assigned_chem_shift_list_1'):
     
     for ix in range(len(loopShifts.rows)):
         row = loopShifts.getRowAsDict(ix)
-        print 'chemical shift: ', \
+        print('chemical shift: ', \
               row['Atom_chem_shift.Seq_ID'], \
               row['Atom_chem_shift.Comp_ID'], \
               row['Atom_chem_shift.Atom_ID'], \
-              row['Atom_chem_shift.Val']
+              row['Atom_chem_shift.Val'])
 
 
 def getKeyValuePairs(dataBlock):
     for (name, save) in dataBlock.saves.items():
-        print 'starting save frame: ', name
+        print('starting save frame: ', name)
         for (key, val) in save.datums.items():
-            print '  key:', key, '  value:', val
-        print '\n'
+            print('  key:', key, '  value:', val)
+        print('\n')
             

--- a/nmrpystar/hierarchical.py
+++ b/nmrpystar/hierarchical.py
@@ -1,5 +1,5 @@
-from .unparse.combinators  import (many0,  seq2L,  count,  not0)
-from .unparse.cst          import (node, cut)
+from nmrpystar.unparse.combinators  import (many0,  seq2L,  count,  not0)
+from nmrpystar.unparse.cst          import (node, cut)
 
 
 (item, satisfy) = (count.item, count.satisfy)

--- a/nmrpystar/nmrstarast.py
+++ b/nmrpystar/nmrstarast.py
@@ -1,6 +1,5 @@
-from . import starast
-from .unparse.maybeerror import MaybeError
-from collections import Counter
+from nmrpystar import starast
+from nmrpystar.unparse.maybeerror import MaybeError
 
 
 class Loop(starast.StarBase):
@@ -191,5 +190,5 @@ def build_nmrstar_ast(data):
         raise TypeError(("expected starast.Data node", data))
     try:
         return MaybeError.pure(build_data(data))
-    except ASTError, e:
+    except ASTError as e:
         return MaybeError.error(e.error)

--- a/nmrpystar/parser.py
+++ b/nmrpystar/parser.py
@@ -1,10 +1,10 @@
-from .scanner import tokenizer
-from .cleantokens import clean_token
-from .hierarchical import nmrstar
-from .starast import concreteToAST
-from .nmrstarast import build_nmrstar_ast
-from .unparse.combinators import run
-from .unparse.maybeerror import MaybeError
+from nmrpystar.scanner import tokenizer
+from nmrpystar.cleantokens import clean_token
+from nmrpystar.hierarchical import nmrstar
+from nmrpystar.starast import concreteToAST
+from nmrpystar.nmrstarast import build_nmrstar_ast
+from nmrpystar.unparse.combinators import run
+from nmrpystar.unparse.maybeerror import MaybeError
 
 
 def _error(**kwargs):
@@ -65,7 +65,7 @@ def parse_cst(string, f_token=token_handler, f_parser=parser_handler):
     # part 2
     tokens = [t for t in tokenized.value['result'] if t['_name'] not in ['whitespace', 'comment']]
     # part 3
-    cleaned = map(clean_token, tokens)
+    cleaned = [clean_token(t) for t in tokens]
     # part 4
     cst = run(nmrstar, cleaned, _FIRST_TOKEN_INDEX)
     if cst.status != 'success':

--- a/nmrpystar/scanner.py
+++ b/nmrpystar/scanner.py
@@ -1,8 +1,17 @@
-from .unparse.combinators import (many0,  optional,  app,   pure,  check,
-                                  seq2R,  seq,       alt,   error,
-                                  seq2L,  position,  not0,  many1, bind,
-                                  zero,   getState)
-from .unparse.cst import (node, sepBy0, cut, addError)
+from nmrpystar.unparse.combinators import (
+    many0,
+    seq2R,
+    seq,
+    alt,
+    error,
+    seq2L,
+    position,
+    not0,
+    many1,
+    bind,
+    zero,
+    getState)
+from nmrpystar.unparse.cst import (node, cut, addError)
 
 
 (item, literal, satisfy) = (position.item, position.literal, position.satisfy)

--- a/nmrpystar/starast.py
+++ b/nmrpystar/starast.py
@@ -1,4 +1,4 @@
-from .unparse.maybeerror import MaybeError
+from nmrpystar.unparse.maybeerror import MaybeError
 
 
 class StarBase(object):
@@ -131,7 +131,7 @@ def buildSave(save):
 
     for d in save['datums']:
         key, value = d['key']['value'], d['value']['value']
-        if datums.has_key(key):
+        if key in datums:
             return bad(nodetype='save', message='duplicate key',
                        key=key, first=key_check[key], second=d['key']['pos'])
         datums[key] = value

--- a/nmrpystar/test/testcleantokens.py
+++ b/nmrpystar/test/testcleantokens.py
@@ -1,4 +1,4 @@
-from ..cleantokens import clean_token, token
+from nmrpystar.cleantokens import clean_token, token
 import unittest as u
 
 
@@ -25,7 +25,7 @@ class TestCleanTokens(u.TestCase):
         ]
         for (inp, name, my_type, value, message) in cases:
             res = clean_token({'_name': 'unquoted', '_state': None, 'first': inp[0], 'rest': list(inp[1:])})
-            print message, res
+            print(message, res)
             if name == 'reserved':
                 if my_type in ['save open', 'data open']:
                     self.assertEqual(token('reserved', None, keyword=my_type, value=value), res)

--- a/nmrpystar/test/testcleantokens.py
+++ b/nmrpystar/test/testcleantokens.py
@@ -54,3 +54,6 @@ class TestCleanTokens(u.TestCase):
         self.assertEqual(token('value', None, value='123'),
                          clean_token(dict(_name='dqstring', _state=None, 
                                           open='"', close='"', value=list('123'))))
+
+if __name__ == "__main__":
+    u.main()

--- a/nmrpystar/test/testexamples/testloading.py
+++ b/nmrpystar/test/testexamples/testloading.py
@@ -1,4 +1,4 @@
-from ...examples import loading
+from nmrpystar.examples import loading
 import unittest
 
 
@@ -14,7 +14,7 @@ class TestLoading(unittest.TestCase):
 
     def testFromFile(self):
         z = loading.parseFile('examples/bmrb17661.txt')
-        print z.value
+        print(z.value)
         self.assertEqual(z.status, 'success')
         # no point in continuing with the tests if the parsing failed!
         data = z.value[1]

--- a/nmrpystar/test/testexamples/testloading.py
+++ b/nmrpystar/test/testexamples/testloading.py
@@ -1,8 +1,8 @@
 from nmrpystar.examples import loading
-import unittest
+import unittest as u
 
 
-class TestLoading(unittest.TestCase):
+class TestLoading(u.TestCase):
     
     def testFromString(self):
         z = loading.parseString()
@@ -14,7 +14,7 @@ class TestLoading(unittest.TestCase):
 
     def testFromFile(self):
         z = loading.parseFile('examples/bmrb17661.txt')
-        print(z.value)
+        # print(z.value)
         self.assertEqual(z.status, 'success')
         # no point in continuing with the tests if the parsing failed!
         data = z.value[1]
@@ -32,3 +32,7 @@ class TestLoading(unittest.TestCase):
         self.assertEqual(len(data.saves['chemical_shift_assignment_data_set_one'].loops[1].keys), 24)
         self.assertEqual(len(data.saves['chemical_shift_assignment_data_set_one'].loops[1].rows), 103)
 '''
+
+
+if __name__ == "__main__":
+    u.main()

--- a/nmrpystar/test/testhierarchical.py
+++ b/nmrpystar/test/testhierarchical.py
@@ -1,7 +1,7 @@
-from .. import hierarchical as p
-from ..cleantokens import token
-from ..unparse import maybeerror as me
-from ..unparse import combinators
+from nmrpystar import hierarchical as p
+from nmrpystar.cleantokens import token
+from nmrpystar.unparse import maybeerror as me
+from nmrpystar.unparse import combinators
 import unittest as u
 
 

--- a/nmrpystar/test/testhierarchical.py
+++ b/nmrpystar/test/testhierarchical.py
@@ -152,3 +152,7 @@ class TestErrors(u.TestCase):
         inp = [save_o, loop, stop, save_c]
         output = m.error([('data block', 1)])
         self.assertEqual(run(p.nmrstar, inp), output)
+
+
+if __name__ == "__main__":
+    u.main()

--- a/nmrpystar/test/testparser.py
+++ b/nmrpystar/test/testparser.py
@@ -1,6 +1,6 @@
-from ..parser import parse_cst, parse_star_ast, parse_nmrstar_ast
-from ..unparse import maybeerror
-from ..starast import Data, Save, Loop
+from nmrpystar.parser import parse_star_ast, parse_nmrstar_ast
+from nmrpystar.unparse import maybeerror
+from nmrpystar.starast import Data, Save, Loop
 import unittest as u
 
 

--- a/nmrpystar/test/testparser.py
+++ b/nmrpystar/test/testparser.py
@@ -62,3 +62,7 @@ class TestParserErrors(u.TestCase):
         self.assertEqual(parse_nmrstar_ast("what is this junk?  this isn't nmr-star"), 
                          bad({'phase': 'CST construction',
                               'message': [('data block', (1,1))]}))
+
+
+if __name__ == "__main__":
+    u.main()

--- a/nmrpystar/test/testscanner.py
+++ b/nmrpystar/test/testscanner.py
@@ -1,6 +1,6 @@
-from .. import scanner
-from ..unparse import maybeerror as me
-from ..unparse import combinators
+from nmrpystar import scanner
+from nmrpystar.unparse import maybeerror as me
+from nmrpystar.unparse import combinators
 import unittest as u
 
 
@@ -58,7 +58,7 @@ class TestScanner(u.TestCase):
             ['data_   not',        5, 'uq: data_'                 ]
         ]
         for (inp, num, message) in cases:
-            print message
+            print(message)
             self.assertEqual(run(token, inp),
                              good(l(inp[num:]), (1, 1+num),
                                   node('unquoted', (1, 1), first=inp[0], rest=list(inp[1:num]))))
@@ -72,7 +72,7 @@ class TestScanner(u.TestCase):
         for (inp, num, pos2, value, message) in cases:
             output = good(l(inp[num:]), pos2, 
                           node('sqstring', (1,1), open="'", close="'", value=list(value)))
-            print message
+            print(message)
             self.assertEqual(run(token, inp), output)
     
     def testDqString(self):
@@ -84,7 +84,7 @@ class TestScanner(u.TestCase):
         for (inp, num, pos2, value, message) in cases:
             output = good(l(inp[num:]), pos2, 
                           node('dqstring', (1,1), open='"', close='"', value=list(value)))
-            print message
+            print(message)
             self.assertEqual(run(token, inp), output)
     
     def testScString(self):
@@ -96,7 +96,7 @@ class TestScanner(u.TestCase):
         for (inp, num, pos0, pos1, pos2, value, message) in cases:
             output = good(l(inp[num:]), pos2, 
                           node('scstring', pos1, value=list(value), open=';', close=list('\n;')))
-            print message
+            print(message)
             self.assertEqual(run(token, inp, pos0), output)
     
     def testUnquotedLeadingSemicolon(self):
@@ -123,7 +123,7 @@ class TestErrors(u.TestCase):
             [';abc 123\na;'  , [('scstring', (1, 1)), ('newline-semicolon', (2, 3))]]
         ]
         for (s, stack) in cases:
-            print stack
+            print(stack)
             output = m.error(stack)
             self.assertEqual(run(token, s), output)
     

--- a/nmrpystar/test/testscanner.py
+++ b/nmrpystar/test/testscanner.py
@@ -131,3 +131,7 @@ class TestErrors(u.TestCase):
         inp = '_ abc'
         output = m.error([('identifier', (1,1)), ('expected non-whitespace', (1,2))])
         self.assertEqual(run(token, inp), output)
+
+
+if __name__ == "__main__":
+    u.main()

--- a/nmrpystar/test/teststarast.py
+++ b/nmrpystar/test/teststarast.py
@@ -161,3 +161,7 @@ class TestErrors(u.TestCase):
                                        node('datum', 28, key=id1, value=val1)])])
         self.assertEqual(buildData(cst), bad(message='duplicate key', nodetype='save',
                                                key='matt', first=(81,3), second=(6,6)))
+
+
+if __name__ == "__main__":
+    u.main()

--- a/nmrpystar/test/teststarast.py
+++ b/nmrpystar/test/teststarast.py
@@ -1,8 +1,8 @@
+from nmrpystar.starast import Loop, Save, Data, buildLoop, buildSave, buildData, concreteToAST
+from nmrpystar.cleantokens import token
+from nmrpystar.unparse import maybeerror as me
+from nmrpystar.test.testhierarchical import loop, stop, id1, id2, val1, val2, data_o, save_o, save_c, node
 import unittest as u
-from ..starast import Loop, Save, Data, buildLoop, buildSave, buildData, concreteToAST
-from ..cleantokens import token
-from ..unparse import maybeerror as me
-from .testhierarchical import loop, stop, id1, id2, val1, val2, data_o, save_o, save_c, node
 
 
 
@@ -39,7 +39,7 @@ class TestAST(u.TestCase):
     def testData(self):
         myData = Data('abc', {'s1': Save({'x': 'y'}, [])})
         self.assertEqual(myData.name, 'abc')
-        self.assertEqual(myData.saves['s1'].datums.keys(), ['x'])
+        self.assertEqual(list(myData.saves['s1'].datums.keys()), ['x'])
         
     def testDataExceptions(self):
         self.assertRaises(TypeError, Data, 'abc', [])

--- a/nmrpystar/unparse/__init__.py
+++ b/nmrpystar/unparse/__init__.py
@@ -1,5 +1,5 @@
-from .maybeerror import MaybeError
-from .combinators import *
+from nmrpystar.unparse.maybeerror import MaybeError
+from nmrpystar.unparse.combinators import *
 
 
 

--- a/nmrpystar/unparse/combinators.py
+++ b/nmrpystar/unparse/combinators.py
@@ -1,4 +1,4 @@
-from .maybeerror import MaybeError as M
+from nmrpystar.unparse.maybeerror import MaybeError as M
 
 
 

--- a/nmrpystar/unparse/cst.py
+++ b/nmrpystar/unparse/cst.py
@@ -1,9 +1,16 @@
 '''
 @author: matt
 '''
-from .combinators import (bind, getState, commit, mapError,
-                          app,  many0,    seq2R,  optional, 
-                          seq, fmap)
+from nmrpystar.unparse.combinators import (
+    bind,
+    getState,
+    commit,
+    mapError,
+    app,
+    many0,
+    optional,
+    seq,
+    fmap)
 
 
 def cut(message, parser):
@@ -28,7 +35,7 @@ def node(name, *pairs):
     3. grabs state at which parsers started
     4. adds an error frame
     """
-    names = map(lambda x: x[0], pairs)
+    names = [x[0] for x in pairs]
     if len(names) != len(set(names)):
         raise ValueError('duplicate names')
     if '_name' in names:

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,35 @@
-from distutils.core import setup
+import setuptools
 
-setup(
+
+with open('README.txt') as f:
+    README = f.read()
+
+setuptools.setup(
     name='NMRPyStar',
     version='1.0.0',
-    packages=['nmrpystar', 
-              'nmrpystar.unparse', 
-              'nmrpystar.examples',
-              'nmrpystar.test'],
+    python_requires=">=3.5",
+    # install_requires=[''],
+    # packages=setuptools.find_packages(),
+    packages=[
+        'nmrpystar',
+        'nmrpystar.unparse'
+    ],
     license='MIT',
     author='Matt Fenwick',
     author_email='mfenwick100@gmail.com',
     url='https://github.com/mattfenwick/NMRPyStar',
-    description='a parser for the NMR-STAR data format'
+    description='a parser for the NMR-STAR data format',
+    # TODO this causes the twine upload to break, need to figure out why
+    # long_description=README,
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Topic :: Software Development :: Libraries',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Intended Audience :: Developers',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='NMRPyStar',
-    version='0.1.0',
+    version='1.0.0',
     packages=['nmrpystar', 
               'nmrpystar.unparse', 
               'nmrpystar.examples',

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,1 @@
-nosetests -v
+python3 -m unittest

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,1 @@
-python3 -m unittest
+python3 -m unittest -v


### PR DESCRIPTION
This is based on https://github.com/mattfenwick/NMRPyStar/pull/5 , huge hat tip to @puinenveturi for doing all the heavy lifting on this!

Changes:

 - watch out for `map` since it doesn't return lists in python3
 - s/urllib2/urllib.request/
 - must decode response from urllib.request.urlopen
 - change imports from relative to absolute https://github.com/mattfenwick/NMRPyStar/issues/4
 - change test runner to `python3 -m unittest`
 - clean up some stray unused imports
 - restore `parse` as an alias for `parse_nmrstar_ast` https://github.com/mattfenwick/NMRPyStar/issues/3

Checklist before merging:

 - [x] do all imports work correctly?
 - [x] update all version references (to 1.0.0 ?)
 - [x] tag commit
 - [x] put up a new pypi release -- https://pypi.org/project/NMRPyStar/1.0.0/
   - [x] pypi install the release and make sure it works and has `parse` available
